### PR TITLE
Datacache

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ var cfenv = require('cfenv');
 var https = require('https');
 var JSON = require('JSON');
 
-var datacache = require('bluemixdatacache');
+var datacache = require('./bluemix_datacache.js');
 
 var async = require('async');
 

--- a/bluemix_datacache.js
+++ b/bluemix_datacache.js
@@ -43,11 +43,15 @@ var get = function(key, callback) {
   request(getOptions('GET', key), function(err, req, body) {
     try {
       //var retval = JSON.parse(body);
-      var retval=body;
+      var retval;
+
+      if (typeof body == 'object')
+           retval=body;
+
       callback(err, retval);
     } catch(e) {
       console.log("Parse exception", body);
-      callback(err, null);
+      callback(true, null);
     }
   });
 };

--- a/bluemix_datacache.js
+++ b/bluemix_datacache.js
@@ -47,6 +47,8 @@ var get = function(key, callback) {
 
       if (typeof body == 'object')
            retval=body;
+      else
+           throw "error";
 
       callback(err, retval);
     } catch(e) {

--- a/bluemix_datacache.js
+++ b/bluemix_datacache.js
@@ -1,0 +1,81 @@
+
+// parse BlueMix  configuration from environment variables, if present
+var services = process.env.VCAP_SERVICES,
+ request = require('request'),
+ debug = require('debug')('datacache'),
+ credentials = null;
+ 
+// load BlueMix credentials from session
+if(typeof services != 'undefined') {
+  services = JSON.parse(services);
+  credentials = services['DataCache-1.0'][0].credentials;
+} 
+
+// formulate the options object to be passed to request
+var getOptions = function(method, key, value) {
+  var options = {
+    uri: credentials.restResource + "/" + credentials.gridName + ".LUT.O/" + encodeURIComponent(key),
+    method: method,
+    auth: {
+      user: credentials.username,
+      pass: credentials.password
+    },
+    json: (typeof value == 'object')?value:true
+  };
+  debug(method, options);
+  return options;
+}
+
+// put a new key/value pair in cache. 'value' is a JS object
+var put = function(key, value, callback) {
+  if (credentials == null) {
+    return callback(true,null);
+  }
+  request(getOptions('POST', key, value), function(err, req, body) {
+    callback(err, body);
+  });
+};
+
+var get = function(key, callback) {
+  if (credentials == null) {
+    return callback(true,null);
+  }
+  request(getOptions('GET', key), function(err, req, body) {
+    try {
+      //var retval = JSON.parse(body);
+      var retval=body;
+      callback(err, retval);
+    } catch(e) {
+      console.log("Parse exception", body);
+      callback(err, null);
+    }
+  });
+};
+
+var remove = function(key, callback) {
+  if (credentials == null) {
+    return callback(true,null);
+  }
+  request(getOptions('DELETE', key), function(err, req, body) {
+    callback(err, body);
+  });
+};
+
+/*put("test",{a:1,b:"bob",c:true}, function(err,data) {
+  console.log("POST",err,data);
+  get("test", function(err, data) {
+    console.log("GET",err,data);
+    remove("test", function(err, data) {
+      console.log("REMOVE",err,data);
+    })
+  })
+});
+*/
+
+module.exports =  {
+  get: get,
+  put: put,
+  remove: remove
+};
+
+

--- a/routes/represent.js
+++ b/routes/represent.js
@@ -27,12 +27,14 @@ module.exports = function (app) {
                 }
                 else {
                     //store in the cache
-                    app.locals.datacache.put(cacheKey, data, function (err, body) {
+                    console.log("represent received " + JSON.stringify(data));
+
+                    app.locals.datacache.put(cacheKey, JSON.stringify(data), function (err, body) {
                         if (err) {
                             console.log("cache error" + JSON.stringify(err));
                         }
                         else {
-                              console.log("cache result: " + JSON.stringify(body));
+                              console.log("cache stored: " + JSON.stringify(body));
                         }
                     });
                     res.send(data);

--- a/routes/represent.js
+++ b/routes/represent.js
@@ -13,9 +13,9 @@ module.exports = function (app) {
         var cacheKey = req.params.code;
 
         app.locals.datacache.get(cacheKey, function (err, data) {
-            if (data) {
+            if (!err) {
                 //in the cache
-                console.log("cache retrieved" + JSON.stringify(data));
+                console.log("cache retrieved");
                 res.send(data);
             }
             else{
@@ -27,8 +27,6 @@ module.exports = function (app) {
                 }
                 else {
                     //store in the cache
-                    console.log("represent received " + JSON.stringify(data));
-
                     app.locals.datacache.put(cacheKey, data, function (err, body) {
                         if (err) {
                             console.log("cache error" + JSON.stringify(err));

--- a/routes/represent.js
+++ b/routes/represent.js
@@ -28,16 +28,8 @@ module.exports = function (app) {
                 else {
                     //store in the cache
                     console.log("represent received " + JSON.stringify(data));
-                    app.locals.datacache.remove(cacheKey, function (err, body) {
-                        if (err){
-                            console.log("cache remove error");
-                        }
-                        else{
-                            console.log("cache removed");
-                        }
-                    });
 
-                    app.locals.datacache.put(cacheKey, JSON.stringify(data), function (err, body) {
+                    app.locals.datacache.put(cacheKey, data, function (err, body) {
                         if (err) {
                             console.log("cache error" + JSON.stringify(err));
                         }

--- a/routes/represent.js
+++ b/routes/represent.js
@@ -28,6 +28,14 @@ module.exports = function (app) {
                 else {
                     //store in the cache
                     console.log("represent received " + JSON.stringify(data));
+                    app.locals.datacache.remove(cacheKey, function (err, body) {
+                        if (err){
+                            console.log("cache remove error");
+                        }
+                        else{
+                            console.log("cache removed");
+                        }
+                    });
 
                     app.locals.datacache.put(cacheKey, JSON.stringify(data), function (err, body) {
                         if (err) {


### PR DESCRIPTION
modified the bluemix_datacache.js and use it locally in order to avoid the bug of it. 

no error returned in the case of cache miss. The body is as <html>404<html>. 

The change only works in the case for JSON data. Not sure for other kinds of cachable data.