### PR TITLE
removed for not working: store the pollenize widgets.js locally,

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "A tool to help people vote",
   "scripts": {
-    "start": "node --expose-gc app.js"
+    "start": "node app.js"
   },
   "dependencies": {
     "JSON": "^1.0.0",


### PR DESCRIPTION
The memory usage of the app is stable at 213MB after the usage had increased for 8 hours.  . 